### PR TITLE
Hotfix for allowedOrigins

### DIFF
--- a/9.0/9.0.1 Commerce/SIF.Sitecore.Commerce/Modules/DeployCommerceContent/DeployCommerceContent.psm1
+++ b/9.0/9.0.1 Commerce/SIF.Sitecore.Commerce/Modules/DeployCommerceContent/DeployCommerceContent.psm1
@@ -83,6 +83,7 @@ Function Invoke-DeployCommerceContentTask {
                 $originalJson.AppSettings.EnvironmentName = "AdventureWorksOpsApi"
 
                 $allowedOrigins = @($CommerceAuthoringBaseUri, $SiteBaseUri)
+                $allowedOrigins = @($SitecoreBizFxBaseUri, $SiteBaseUri)
                 $originalJson.AppSettings.AllowedOrigins = $allowedOrigins
                 $originalJson.AppSettings.SslPort = $CommerceOpsServicesPort
                 $originalJson.AppSettings.SitecoreIdentityServerUrl = $SitecoreIdentityServerBaseUri
@@ -249,6 +250,7 @@ Function Invoke-DeployCommerceContentTask {
                 $originalJson = Get-Content $pathToJson -Raw | ConvertFrom-Json
 
                 $allowedOrigins = @($SitecoreBizFxBaseUri)
+                $allowedOrigins = @($SitecoreBizFxBaseUri, $SiteBaseUri)
                 $originalJson.AppSettings.AllowedOrigins = $allowedOrigins
                 if ($_ -match "CommerceShops") {
                     $originalJson.AppSettings.SslPort = $CommerceShopsServicesPort


### PR DESCRIPTION
Hotfix for allowedOrigins, by default Sitecore change to the allowedorigins in DeployCommerceContent.psm1 was: $allowedOrigins = @("https://localhost:4200", "https://$SiteHostHeaderName"), the 4200 was the BizFx server + Site name, so not the authoring base uri